### PR TITLE
added dynamic cards for plant on root page

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Plant;
+use Illuminate\Http\Request;
+
+class HomeController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+{
+    $plants = Plant::paginate(12); // Fetch 12 plants per page
+    return view('posts', compact('plants'));
+}
+
+
+    // Other methods...
+}

--- a/app/Http/Controllers/PlantController.php
+++ b/app/Http/Controllers/PlantController.php
@@ -4,6 +4,8 @@ namespace App\Http\Controllers;
 
 use App\Models\Plant;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+
 
 class PlantController extends Controller
 {
@@ -11,10 +13,15 @@ class PlantController extends Controller
      * Display a listing of the resource.
      */
     public function index()
-    {
-        $plants = Plant::all();
-        return view('plants.index', compact('plants'));
-    }
+{
+    $plants = Cache::remember('plants', 60 * 60, function () {
+        return Plant::paginate(12);
+    });
+
+    return view('posts', compact('plants'));
+}
+    
+
 
     /**
      * Show the form for creating a new resource.
@@ -35,6 +42,8 @@ class PlantController extends Controller
             'description' => 'required|string',
             // Add other validation rules as needed
         ]);
+
+        Cache::forget('plants');
 
         // Create a new plant
         $plant = Plant::create([
@@ -76,6 +85,8 @@ class PlantController extends Controller
             // Add other validation rules as needed
         ]);
 
+        Cache::forget('plants');
+        
         // Update the plant's data
         $plant->update([
             'title' => $request->title,
@@ -92,6 +103,7 @@ class PlantController extends Controller
      */
     public function destroy(Plant $plant)
     {
+        Cache::forget('plants');
         $plant->delete();
         return redirect()->route('plants.index')->with('success', 'Plant deleted successfully.');
     }

--- a/resources/views/components/plant-card-index.blade.php
+++ b/resources/views/components/plant-card-index.blade.php
@@ -1,0 +1,12 @@
+<div class="bg-green-900 p-4 rounded-lg shadow-lg hover:shadow-2xl transition-shadow duration-200 ease-in-out transform hover:scale-105">
+    <div class="flex items-center">
+        <span class="text-green-300 text-sm mr-2">{{ $plant->user->name }}</span>
+        <h2 class="text-green-200 text-lg font-semibold">{{ $plant->name }}</h2>
+    </div>
+    <div class="mt-2">
+        <img src="{{ $plant->image_url }}" alt="{{ $plant->name }}" class="w-full h-48 object-cover rounded-lg">
+    </div>
+    <div class="mt-2">
+        <span class="text-green-400 text-sm">Category: {{ $plant->category->name }}</span>
+    </div>
+</div>

--- a/resources/views/posts.blade.php
+++ b/resources/views/posts.blade.php
@@ -3,107 +3,54 @@
     <head>
         <style>
             body {
-                background-color: #004d40;
+                background-color: #002604;
                 color: #b2dfdb;
             }
+        
             .post-card {
-            background-color: #00796b;
-            border-radius: 10px;
-            padding: 20px;
-            transition: transform 0.3s ease, box-shadow 0.3s ease;
-        }
+                background-color: #017a0d;
+                border-radius: 10px;
+                padding: 20px;
+                transition: transform 0.3s ease, box-shadow 0.3s ease;
+            }
 
-        .post-card:hover {
-            transform: translateY(-5px) rotate(-2deg); /* Rotate the card slightly to make it jiggle */
-            box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3), 0 0 20px rgba(255, 143, 0, 0.5); /* Add glow effect using box-shadow */
+            .post-card:hover {
+                transform: scale(1.05); /* Scale the card slightly to make it magnify */
+                box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3), 0 0 20px rgba(255, 143, 0, 0.5); /* Add glow effect using box-shadow */
+            }
 
-        }
+            .accent {
+                color: #ff8f00;
+            }
 
-        .accent {
-            color: #ff8f00;
-        }
+            /* Style for the image */
+            .card-image {
+                border-radius: 10px; /* Apply rounded corners to all sides of the image */
+            }
 
-        /* Different sizes for the cards */
-        .post-card.small {
-            height: 200px;
-        }
 
-        .post-card.medium {
-            height: 350px;
-        }
+            .card-footer {
+                border-radius: 0 0 10px 10px; /* Apply rounded corners to the bottom of the card-footer */
+            }
 
-        .post-card.large {
-            height: 500px;
-        }
     </style>
 </head>
 <section class="px-6 py-8">
     <main class="max-w-6xl mx-auto mt-10 lg:mt-20 space-y-6">
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            <article class="post-card">
-                <h2 class="text-2xl font-bold mb-2">Post 1 Title</h2>
-                <p class="mb-4">This is a summary or excerpt of post 1. You can add more content here.</p>
-                <a href="#" class="accent">Read More &rarr;</a>
-            </article>
-            <article class="post-card">
-                <h2 class="text-2xl font-bold mb-2">Post 2 Title</h2>
-                <p class="mb-4">This is a summary or excerpt of post 2. You can add more content here.</p>
-                <a href="#" class="accent">Read More &rarr;</a>
-            </article>
-            <article class="post-card">
-                <h2 class="text-2xl font-bold mb-2">Post 3 Title</h2>
-                <p class="mb-4">This is a summary or excerpt of post 3. You can add more content here.</p>
-                <a href="#" class="accent">Read More &rarr;</a>
-            </article>
-            <article class="post-card">
-                <h2 class="text-2xl font-bold mb-2">Post 4 Title</h2>
-                <p class="mb-4">This is a summary or excerpt of post 4. You can add more content here.</p>
-                <a href="#" class="accent">Read More &rarr;</a>
-            </article>
-            <article class="post-card">
-                <h2 class="text-2xl font-bold mb-2">Post 5 Title</h2>
-                <p class="mb-4">This is a summary or excerpt of post 5. You can add more content here.</p>
-                <a href="#" class="accent">Read More &rarr;</a>
-            </article>
-            <article class="post-card">
-                <h2 class="text-2xl font-bold mb-2">Post 6 Title</h2>
-                <p class="mb-4">This is a summary or excerpt of post 6. You can add more content here.</p>
-                <a href="#" class="accent">Read More &rarr;</a>
-            </article>
-            <article class="post-card">
-                <h2 class="text-2xl font-bold mb-2">Post 7 Title</h2>
-                <p class="mb-4">This is a summary or excerpt of post 7. You can add more content here.</p>
-                <a href="#" class="accent">Read More &rarr;</a>
-            </article>
-            <article class="post-card">
-                <h2 class="text-2xl font-bold mb-2">Post 8 Title</h2>
-                <p class="mb-4">This is a summary or excerpt of post 8. You can add more content here.</p>
-                <a href="#" class="accent">Read More &rarr;</a>
-            </article>
-            <article class="post-card">
-                <h2 class="text-2xl font-bold mb-2">Post 9 Title</h2>
-                <p class="mb-4">This is a summary or excerpt of post 9. You can add more content here.</p>
-                <a href="#" class="accent">Read More &rarr;</a>
-            </article>
-            
+            @foreach($plants as $plant)
+                <article class="post-card">
+                    <div class="rounded-xl">
+                        <img class="card-image border-4 border-green-800 rounded-xl" src="{{ $plant->image_url }}" alt="Plant image">
+                    </div>
+                    <h2 class="text-2xl font-bold mb-2">{{ $plant->name }}</h2>
+                    <p class="mb-4">{{ $plant->category->name }}</p>
+                    <p class="text-sm mb-4">Posted by: {{ $plant->user->name }}</p>
+                    <a href="{{ route('plants.show', $plant) }}" class="accent">Read More &rarr;</a>
+                </article>
+            @endforeach
         </div>
+        {{ $plants->links() }}
     </main>
 </section>
-<script>
-    // Function to assign random size classes to post-card elements
-    function randomizeCardSize() {
-        const cards = document.querySelectorAll('.post-card');
-        const sizes = ['small', 'medium', 'large'];
-
-        cards.forEach(card => {
-            const randomSize = sizes[Math.floor(Math.random() * sizes.length)];
-            card.classList.add(randomSize);
-        });
-    }
-
-    // Call the randomizeCardSize function on page load
-    window.addEventListener('DOMContentLoaded', () => {
-        randomizeCardSize();
-    });
-</script>
 </x-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,9 @@ use App\Http\Controllers\PlantController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\HomeController;
+
+
 
 /*
 |--------------------------------------------------------------------------
@@ -18,9 +21,12 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::get('/', function () {
-    return view('posts');
-});
+// Route::get('/', function () {
+//     return view('posts');
+// });
+
+Route::get('/', [HomeController::class, 'index'])->name('home');
+
 
 Route::get('/dashboard', function () {
     return view('dashboard');


### PR DESCRIPTION
Implemented dynamic cards for displaying plants on the root page:
- Modified the PlantController to fetch plants with pagination (12 plants per page).
- Updated the 'posts.blade.php' template to display plant cards using a grid layout.
- Added pagination links at the bottom of the plant cards grid.

Improved page load performance:
- Leveraged caching in the PlantController to cache the paginated plants for faster retrieval.
- Updated create, update, and delete methods in the PlantController to invalidate the cache when plant data changes.
